### PR TITLE
stop showing EPIPE

### DIFF
--- a/lib/jsonCommand.js
+++ b/lib/jsonCommand.js
@@ -452,8 +452,16 @@ JSON.Command.prototype.processInput = function() {
       }
     });
 
+    var handleEPIPE = function(e) {
+      if (e.code !== "EPIPE") {
+        process.emit("error", e);
+      }
+    };
+    process.stdout.on("error", handleEPIPE);
+
     this.stdin.on("end", function() {
       this.jsonC.processObjects([this.jsonC.buffer, null]);
+      process.stdout.removeListener("error", handleEPIPE);
     });
   }
 };


### PR DESCRIPTION
`json-command` is a nice tool!
Whenever I parse json, I use this awesome product.

But the following error occurred, when I give large buffer and use pager:

``` sh
$ node --version
v0.6.18
$ pwd
~/json_command
$ seq 1 10000 | ./bin/json.js | less
```

And close pager without reading all buffer:

```
events.js:48
        throw arguments[1]; // Unhandled 'error' event
                       ^
Error: write EPIPE
    at errnoException (net.js:670:11)
    at Object.afterWrite [as oncomplete] (net.js:503:19)
```

The reason why this error occurred, `process.stdout.write` throw error `EPIPE` when the pager(such as `less`, `lv`)  closed  before reading all buffer.

I think that this case should not throw error.
Therefor, I stopped showing this error in the way to ignore `EPIPE`.

I tested my patch in the following node versions:

```
v0.4.12
v0.6.18
v0.7.8
```
