### PR TITLE
Add -, option for leading-comma / diff-friendly / Node-style output

### DIFF
--- a/lib/jsonCommand.js
+++ b/lib/jsonCommand.js
@@ -14,6 +14,7 @@ JSON.Command = function(args) {
   this.keys = [];
   this.transformedKeys = [];
   this.uglyOutput = false;
+  this.leadingComma = false;
   this.inspectOutput = false;
   this.headerPassthrough = false;
   this.columnOutput = false;
@@ -40,6 +41,7 @@ JSON.Command.prototype.printhelp = function() {
   console.log("  -h                    print this help info and exit\n");
   console.log("  -v (-V | --version)   print version number and exit\n");
   console.log("  -u                    print ugly json output, each object on a single line\n");
+  console.log("  -,                    print leading-comma diff-friendly output, one line per property\n");
   console.log("  -d                    print debugging output including exception messages\n");
   console.log("  -o object.path        specify the path to an array to be iterated on\n");
   console.log("  new.key=old_key       move old_key to new.key in output object\n");
@@ -78,8 +80,15 @@ JSON.Command.prototype.printversion = function() {
 
 JSON.Command.prototype.stringify = function(obj) {
   return( this.inspectOutput ? util.inspect(obj, false, Infinity, true)
+        : this.leadingComma ? this.diffFriendly(obj)
         : this.uglyOutput ? JSON.stringify(obj)
         : JSON.stringify(obj, null, 2) );
+};
+
+JSON.Command.prototype.diffFriendly = function(obj) {
+  return JSON.stringify(obj, null, 2)
+    .replace(/ ?([[{,])\n ( *)(?: )/gm, '\n$2$1 ')
+    .replace(/(^|, ?)\n *{/gm, '$1{');
 };
 
 JSON.Command.prototype.debug = function(msg) {
@@ -128,6 +137,9 @@ JSON.Command.prototype.processArgs = function processArgs(args) {
         break;
       case "-u": // pretty printing (turn off)
         this.uglyOutput = true;
+        break;
+      case "-,": // diff-friendlier output
+        this.leadingComma = true;
         break;
       case "-c": // conditional
         this.conditionals.push(a.shift());


### PR DESCRIPTION
This patch lets `json -,` produce output akin to the format used in `package.json` for friendlier diffs / changesets under source control. Maybe it should have some alphabetical flag instead, but I couldn't really come up with anything more intuitive.
